### PR TITLE
Add compatibility with Spring Boot 3.0

### DIFF
--- a/tuya-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/tuya-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.tuya.connector.open.spring.boot.TuyaAutoConfiguration


### PR DESCRIPTION
This PR adds support for registering auto-configuration classes using `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports`, which was added in Spring Boot 2.7 as a replacement for `org.springframework.boot.autoconfigure.EnableAutoConfiguration` key in `META-INF/spring.factories`.

Additionally, Spring Boot 3.0 removed support for discovering auto-configuration classes using `META-INF/spring.factories` so `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` is required in order for auto-configuration classes to be discovered.

See here for more details:
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes#auto-configuration-registration
- https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-3.0-Migration-Guide#auto-configuration-files

Note that I also opened the equivalent PR in tuya/connector#15.