### PR TITLE
Upgrade FastJSON to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <junit-jupiter.version>5.7.0</junit-jupiter.version>
         <lombok.version>1.18.18</lombok.version>
         <logback.version>1.2.3</logback.version>
-        <fastjson.version>1.2.73</fastjson.version>
+        <fastjson.version>1.2.83</fastjson.version>
         <spring-boot.version>2.1.1.RELEASE</spring-boot.version>
         <pulsar-client.version>2.7.1</pulsar-client.version>
         <annotation-api.version>1.3.2</annotation-api.version>


### PR DESCRIPTION
FastJSON versions <1.2.83 are affected by CVE-2022-25845.