### PR TITLE
Improve TuyaMessageDispatcher logging

### DIFF
--- a/tuya-messaging/src/main/java/com/tuya/connector/open/messaging/TuyaMessageDispatcher.java
+++ b/tuya-messaging/src/main/java/com/tuya/connector/open/messaging/TuyaMessageDispatcher.java
@@ -149,7 +149,7 @@ public class TuyaMessageDispatcher implements MessageDispatcher, ApplicationCont
                         consumerFlag = true;
                     } catch (Exception e) {
                         consumerFlag = false;
-                        log.debug(String.format("###TUYA_PULSAR_MSG => Consume tuya message error, msgId: %s, tid: %s ", msgId, tid), e);
+                        log.error(String.format("###TUYA_PULSAR_MSG => Consume tuya message error, msgId: %s, tid: %s ", msgId, tid), e);
                     } finally {
                         if (Objects.nonNull(message)) {
                             try {


### PR DESCRIPTION
As of commit 0068cfca any exception thrown by the consumer will be logged at debug level. This makes it very difficult to track errors that occur while consuming the message.

This commit improves logging in `TuyaMessageDispatcher` by logging consumer errors at error level again.