### PR TITLE
feat: expose Pulsar MessageId to event listeners via uuid field

### DIFF
--- a/tuya-messaging/src/main/java/com/tuya/connector/open/messaging/TuyaMessageDispatcher.java
+++ b/tuya-messaging/src/main/java/com/tuya/connector/open/messaging/TuyaMessageDispatcher.java
@@ -142,6 +142,8 @@ public class TuyaMessageDispatcher implements MessageDispatcher, ApplicationCont
                         String payload = new String(message.getData());
                         SourceMessage sourceMessage = JSON.parseObject(payload, SourceMessage.class);
                         BaseTuyaMessage msg = MessageRegister.extract(sourceMessage, sk);
+                        // Expose Pulsar MessageId to event listeners for traceability and deduplication
+                        msg.setUuid(msgId.toString());
                         log.debug("###TUYA_PULSAR_MSG => start process message, messageId={}, publishTime={}, tid={}, payload={}",
                             msgId, publishTime, tid, payload);
                         ctx.publishEvent(msg);


### PR DESCRIPTION
## Summary

Set the `uuid` field on `BaseTuyaMessage` with the Pulsar `MessageId` before publishing to Spring ApplicationContext.

## Changes

Single line addition in `TuyaMessageDispatcher.java`:
```java
msg.setUuid(msgId.toString());
```

## Motivation

Currently, the Pulsar `MessageId` and `tid` are captured and logged but not exposed to `@EventListener` consumers. This makes it difficult to:

- **Deduplicate messages** at the application level
- **Trace database/InfluxDB records** back to source Pulsar events  
- **Debug and audit** message processing

The `uuid` field already exists on `BaseTuyaMessage` but is never populated - this PR simply populates it with the readily available `MessageId`.

## Backward Compatibility

This change is fully backward compatible:
- Existing consumers that don't use `uuid` are unaffected
- No API changes required
- No configuration changes needed

Fixes #55